### PR TITLE
Render application block on homepage

### DIFF
--- a/src/graphql/data.ts
+++ b/src/graphql/data.ts
@@ -15,7 +15,6 @@ import type {
 } from './types';
 
 const EMPTY_ARRAY = [] as const;
-const EMPTY_OBJECT = {} as const;
 
 const monthAndYearFormat = new Intl.DateTimeFormat('en-US', {
 	month: 'long',
@@ -58,7 +57,7 @@ const client = new GraphQLClient(
 
 async function getData() {
 	try {
-		const [collabiesResponse, FrontPageApplicationBlock, techTalkResponse] =
+		const [collabiesResponse, frontPageApplicationBlock, techTalkResponse] =
 			await Promise.all([
 				client.request<CollabiesAndTeamsResponse>(CollabiesAndTeamsQuery),
 				client.request<FrontPageApplicationBlockResponse>(
@@ -99,6 +98,9 @@ async function getData() {
 			return team;
 		});
 
+		const applicationBlock =
+			frontPageApplicationBlock.textBlocks[0].textContent.html;
+
 		const techTalks = techTalkResponse.techTalks.map((talk) => {
 			const rgx = /(v=([\w-]+))|(be\/([\w-]+))/; // there's probably room for improvement here
 			talk.formattedDate = fullDateShortMonthFormat.format(
@@ -121,6 +123,7 @@ async function getData() {
 		});
 
 		return {
+			applicationBlock,
 			mentors,
 			teams,
 			techTalks,
@@ -130,6 +133,7 @@ async function getData() {
 		console.error('Error fetching GraphQL data', err);
 
 		return {
+			applicationBlock: '',
 			mentors: EMPTY_ARRAY,
 			teams: EMPTY_ARRAY,
 			techTalks: EMPTY_ARRAY,
@@ -138,4 +142,5 @@ async function getData() {
 	}
 }
 
-export const { mentors, teams, techTalks, volunteers } = await getData();
+export const { applicationBlock, mentors, teams, techTalks, volunteers } =
+	await getData();

--- a/src/graphql/data.ts
+++ b/src/graphql/data.ts
@@ -1,15 +1,21 @@
 import { GraphQLClient } from 'graphql-request';
 
-import { CollabiesAndTeamsQuery, TechTalksQuery } from './queries';
+import {
+	CollabiesAndTeamsQuery,
+	FrontPageApplicationBlockQuery,
+	TechTalksQuery,
+} from './queries';
 import type {
 	Bio,
 	CollabieData,
 	CollabiesAndTeamsResponse,
+	FrontPageApplicationBlockResponse,
 	Role,
 	TechTalkResponse,
 } from './types';
 
 const EMPTY_ARRAY = [] as const;
+const EMPTY_OBJECT = {} as const;
 
 const monthAndYearFormat = new Intl.DateTimeFormat('en-US', {
 	month: 'long',
@@ -52,10 +58,14 @@ const client = new GraphQLClient(
 
 async function getData() {
 	try {
-		const [collabiesResponse, techTalkResponse] = await Promise.all([
-			client.request<CollabiesAndTeamsResponse>(CollabiesAndTeamsQuery),
-			client.request<TechTalkResponse>(TechTalksQuery),
-		]);
+		const [collabiesResponse, FrontPageApplicationBlock, techTalkResponse] =
+			await Promise.all([
+				client.request<CollabiesAndTeamsResponse>(CollabiesAndTeamsQuery),
+				client.request<FrontPageApplicationBlockResponse>(
+					FrontPageApplicationBlockQuery,
+				),
+				client.request<TechTalkResponse>(TechTalksQuery),
+			]);
 
 		const collabies = collabiesResponse.collabies.map((c) => {
 			// Flatten the bio prop to just the `html` string

--- a/src/graphql/data.ts
+++ b/src/graphql/data.ts
@@ -1,15 +1,15 @@
 import { GraphQLClient } from 'graphql-request';
 
 import {
+	ApplicationBlockQuery,
 	CollabiesAndTeamsQuery,
-	FrontPageApplicationBlockQuery,
 	TechTalksQuery,
 } from './queries';
 import type {
+	ApplicationBlockResponse,
 	Bio,
 	CollabieData,
 	CollabiesAndTeamsResponse,
-	FrontPageApplicationBlockResponse,
 	Role,
 	TechTalkResponse,
 } from './types';
@@ -57,14 +57,15 @@ const client = new GraphQLClient(
 
 async function getData() {
 	try {
-		const [collabiesResponse, frontPageApplicationBlock, techTalkResponse] =
+		const [applicationBlockResponse, collabiesResponse, techTalkResponse] =
 			await Promise.all([
+				client.request<ApplicationBlockResponse>(ApplicationBlockQuery),
 				client.request<CollabiesAndTeamsResponse>(CollabiesAndTeamsQuery),
-				client.request<FrontPageApplicationBlockResponse>(
-					FrontPageApplicationBlockQuery,
-				),
 				client.request<TechTalkResponse>(TechTalksQuery),
 			]);
+
+		const applicationBlock =
+			applicationBlockResponse.textBlocks[0].textContent.html;
 
 		const collabies = collabiesResponse.collabies.map((c) => {
 			// Flatten the bio prop to just the `html` string
@@ -97,9 +98,6 @@ async function getData() {
 			team.teamNumber = calculateTeamNumber(team.anchor);
 			return team;
 		});
-
-		const applicationBlock =
-			frontPageApplicationBlock.textBlocks[0].textContent.html;
 
 		const techTalks = techTalkResponse.techTalks.map((talk) => {
 			const rgx = /(v=([\w-]+))|(be\/([\w-]+))/; // there's probably room for improvement here

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -1,5 +1,20 @@
 import { gql } from 'graphql-request';
 
+export const ApplicationBlockQuery = gql`
+	query ApplicationBlock {
+		textBlocks(
+			where: {
+				internalName_contains: "Front Page – Applications"
+				visible: true
+			}
+		) {
+			textContent {
+				html
+			}
+		}
+	}
+`;
+
 const COLLABIE_DATA_FRAGMENT = gql`
 	fragment collabieData on Collabie {
 		bio {
@@ -36,21 +51,6 @@ export const CollabiesAndTeamsQuery = gql`
 		}
 	}
 	${COLLABIE_DATA_FRAGMENT}
-`;
-
-export const FrontPageApplicationBlockQuery = gql`
-	query FrontPageApplicationBlock {
-		textBlocks(
-			where: {
-				internalName_contains: "Front Page – Applications"
-				visible: true
-			}
-		) {
-			textContent {
-				html
-			}
-		}
-	}
 `;
 
 export const TechTalksQuery = gql`

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -38,6 +38,21 @@ export const CollabiesAndTeamsQuery = gql`
 	${COLLABIE_DATA_FRAGMENT}
 `;
 
+export const FrontPageApplicationBlockQuery = gql`
+	query FrontPageApplicationBlock {
+		textBlocks(
+			where: {
+				internalName_contains: "Front Page – Applications"
+				visible: true
+			}
+		) {
+			textContent {
+				html
+			}
+		}
+	}
+`;
+
 export const TechTalksQuery = gql`
 	query TechTalks {
 		techTalks(orderBy: dateAndTime_DESC) {

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -36,7 +36,7 @@ export interface CollabiesAndTeamsResponse {
 	teams: DeveloperTeam[];
 }
 
-export interface FrontPageApplicationBlockResponse {
+export interface ApplicationBlockResponse {
 	textBlocks: {
 		textContent: {
 			html: string;

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -37,9 +37,11 @@ export interface CollabiesAndTeamsResponse {
 }
 
 export interface FrontPageApplicationBlockResponse {
-	textContent: {
-		html: string;
-	};
+	textBlocks: {
+		textContent: {
+			html: string;
+		};
+	}[];
 }
 
 export interface TechTalk {

--- a/src/graphql/types.ts
+++ b/src/graphql/types.ts
@@ -36,6 +36,12 @@ export interface CollabiesAndTeamsResponse {
 	teams: DeveloperTeam[];
 }
 
+export interface FrontPageApplicationBlockResponse {
+	textContent: {
+		html: string;
+	};
+}
+
 export interface TechTalk {
 	title: string;
 	presenters: Pick<CollabieData, 'fullName'>;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import { BaseLayout } from '@layouts';
+import { applicationBlock } from '@graphql';
 ---
 
 <BaseLayout
@@ -54,7 +55,7 @@ import { BaseLayout } from '@layouts';
 		</span>
 	</blockquote>
 
-	<!-- TODO: Add application block -->
+	<Fragment set:html={applicationBlock} />
 
 	<h2>So you want to…</h2>
 


### PR DESCRIPTION
## Summary
Adds logic to get the application block HTML from Hygraph and then render it on the homepage.

![CleanShot 2022-10-01 at 19 56 07@2x](https://user-images.githubusercontent.com/13525251/193435863-0390e0a0-597e-4546-bcce-837c23adfbdc.png)

## Test plan
Check out [the deploy preview](https://deploy-preview-1--tcl-site-next.netlify.app/) to see the new HTML on the homepage.